### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: adopt
+          distribution: 'temurin'
           cache: gradle
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,23 @@
 name: Java CI
-
-on: [push, pull_request_target]
-
+on:
+  - push
+  - pull_request_target
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
-          cache: gradle # Changed from maven to gradle
-      - name: Build with Gradle # Updated task name
-        run: ./gradlew build # Changed Maven command to Gradle command
+          distribution: adopt
+          cache: gradle
+      - name: Build with Gradle
+        run: ./gradlew build
       - uses: mate-academy/auto-approve-action@v2
         if: ${{ github.event.pull_request && success() }}
         with:


### PR DESCRIPTION
This PR updates GitHub Actions versions:
- actions/checkout from v2 to v4
- actions/setup-java from v2 to v4